### PR TITLE
Add missing include to SMXManager

### DIFF
--- a/sdk/Windows/SMXManager.cpp
+++ b/sdk/Windows/SMXManager.cpp
@@ -3,7 +3,7 @@
 #include "SMXDeviceConnection.h"
 #include "SMXDeviceSearchThreaded.h"
 #include "Helpers.h"
-
+#include <stdexcept>
 #include <windows.h>
 #include <memory>
 using namespace std;


### PR DESCRIPTION
I needed to include `<stdexcept>` to be able to compile the project successfully with VS 2022 - without it, the compiler fails on not being able to find the identifier for `runtime_error`.