### PR TITLE
Fix GIF uploading bug

### DIFF
--- a/sdk/Windows/SMXGif.cpp
+++ b/sdk/Windows/SMXGif.cpp
@@ -83,8 +83,11 @@ public:
     void ReadBytes(string &s, int count)
     {
         s.clear();
-        while(count--)
+        s.reserve(count); // Reserve memory to avoid multiple allocations
+        for (int i = 0; i < count; ++i)
+        {
             s.push_back(ReadByte());
+        }
     }
 
     void skip(int bytes)
@@ -142,9 +145,9 @@ public:
         while(1)
         {
             uint8_t blocksize = stream.ReadByte();
-            stream.skip(blocksize);
-            if(bytes_remaining == 0)
+            if (blocksize == 0)
                 break;
+            stream.skip(blocksize);
         }
     }
 
@@ -211,6 +214,8 @@ string LWZDecoder::DecodeImage()
             next_free_slot = clear + 2;
             prev_code1 = -1;
             prev_code2 = -1;
+            dictionary.clear();
+            dictionary.resize(1 << GIFBITS);
             continue;
         }
 

--- a/sdk/Windows/SMXPanelAnimationUpload.cpp
+++ b/sdk/Windows/SMXPanelAnimationUpload.cpp
@@ -6,6 +6,7 @@
 #include "Helpers.h"
 #include <string>
 #include <vector>
+#include <array>
 using namespace std;
 using namespace SMX;
 
@@ -23,12 +24,12 @@ using namespace SMX;
 namespace
 {
     // Panel names for error messages.
-    static const char *panel_names[] = {
+    static const std::array<const char*, 9> panel_names = {
         "up-left", "up", "up-right",
         "left", "center", "right",
         "down-left", "down", "down-right",
     };
-}
+}  // namespace
 
 // These structs are the protocol we use to send offline graphics to the pad.
 // This isn't related to realtime lighting.
@@ -89,8 +90,9 @@ namespace PanelLightGraphic
 
         uint16_t offset = 0;
         uint8_t size = 0;
-        uint8_t data[240];
+        std::array<uint8_t, 240> data = { 0 }; // Initialize the array with zeros
     };
+
 #pragma pack(pop)
 
 #pragma pack(push, 1)
@@ -316,7 +318,7 @@ namespace ProtocolHelpers
 
             int bytes_left = size - offset;
             packet.size = min(sizeof(PanelLightGraphic::upload_packet::data), bytes_left);
-            memcpy(packet.data, buf, packet.size);
+            memcpy(packet.data.data(), buf, packet.size); // Use data() to get the pointer
             packets.push_back(packet);
 
             offset += packet.size;


### PR DESCRIPTION
Currently, one usually has to upload the gif multiple times before it's properly applied to the stage (at least with Gen4/Gen5, this is a commonly known issue - not sure if earlier model stages are affected?). This fixes the relevant bugs preventing it from uploading correctly the first time.

1. Reserve memory to avoid multiple allocations in `ReadBytes`
2. Reorganize skip-past-end-of-data method in `ReadLZWCode`
3. Expand method to clear the dictionary in `LWZDecoder::DecodeImage()`
4. Use a `std::array` instead of a raw array
5. Initialize the array with zeros
6. Use `data()` to get the pointer of the packet data in `CreateUploadPackets`